### PR TITLE
Don't update page title when MessageRate is null

### DIFF
--- a/public_html/script.js
+++ b/public_html/script.js
@@ -761,7 +761,7 @@ function refreshPageTitle() {
                 subtitle += TrackedAircraftPositions + '/' + TrackedAircraft;
         }
 
-        if (MessageRateInTitle) {
+        if (MessageRateInTitle && MessageRate !== null) {
                 if (subtitle) subtitle += ' | ';
                 subtitle += MessageRate.toFixed(1) + '/s';
         }


### PR DESCRIPTION
Prevents error calling toFixed() on a null MessageRate. This error was crashing the script and preventing the page from working at all.
